### PR TITLE
DM-28230: fix the RotatorCommander

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,21 @@
 Version History
 ###############
 
+v0.10.3
+=======
+
+Changes:
+
+* Fix an error in RotatorCommander.
+
+Requires:
+* ts_hexrotcomm 0.12
+* ts_salobj 6.1
+* ts_simactuators 1
+* ts_idl 2.2
+* ts_xml 7.0
+* MTRotator IDL files, e.g. made using ``make_idl_files.py MTRotator``
+
 v0.10.2
 =======
 


### PR DESCRIPTION
It overrode a standard method with a different signature, which broke some telemetry topics.