### PR TITLE
Some updates so conda package can be built.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,9 +21,9 @@ build:
 test:
   requires:
     - ts-conda-build =0.3
-    - ts-idl {{ idl_version }}
-    - ts-salobj {{ salobj_version }}
-    - ts-hexrotcomm
+    - ts-idl =3.7.0_10.2.0_6.1.0
+    - ts-salobj =6.9
+    - ts-hexrotcomm =0.28
     - ts-simactuators
   source_files:
     - python

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,8 +6,23 @@
 Version History
 ###############
 
-cycle24test1.5.0
-----------------
+v0.22.2
+-------
+
+* Update conda recipe to pin version of ts_idl, ts_salobj and ts_hexrotcomm to the compatible versions.
+
+Requires:
+
+* ts_rotator_controller 1.5.0 prototype 2022-04-5
+* ts_hexrotcomm 0.28
+* ts_salobj 6.8
+* ts_idl 3.4
+* ts_xml 10.2
+* MTRotator and MTMount IDL files, e.g. made using ``make_idl_files.py MTRotator MTMount``
+
+
+v0.22.1
+-------
 
 * Update for ts_rotator_controller 1.5.0
   This is a temporary version intended for use with cycle build 24.


### PR DESCRIPTION
Note that the PR is done against the "release/v0.22" branch, which I created to track the release version.

This PR updates the conda recipe to pin the version of ts_idl, ts_salobj and ts_hexrotcomm to the compatible ones.
