### PR TITLE
Increase the delay time in move command and publish the error codes.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ###############
 
+v1.2.4
+------
+
+* Increase the delay time from 0.1 sec to 0.2 sec in ``RotatorCsc.do_move()``.
+* Publish the error code events.
+
 v1.2.3
 ------
 

--- a/python/lsst/ts/mtrotator/rotator_csc.py
+++ b/python/lsst/ts/mtrotator/rotator_csc.py
@@ -171,7 +171,7 @@ class RotatorCsc(hexrotcomm.BaseCsc):
                     self.log.error(err_msg)
 
                     # TODO: Use the ErrorCode.NO_NEW_CCW_TELEMETRY instead in
-                    # ts_xml v23.0.0
+                    # ts_xml v23.0.0 (DM-48161)
                     await self.evt_errorCode.set_write(
                         errorCode=4,
                         errorReport=err_msg,
@@ -195,7 +195,7 @@ class RotatorCsc(hexrotcomm.BaseCsc):
                     self.log.error(err_msg)
 
                     # TODO: Use the ErrorCode.OLD_CCW_TELEMETRY instead in
-                    # ts_xml v23.0.0
+                    # ts_xml v23.0.0 (DM-48161)
                     await self.evt_errorCode.set_write(
                         errorCode=5,
                         errorReport="Camera cable wrap telemetry is too old",
@@ -235,7 +235,7 @@ class RotatorCsc(hexrotcomm.BaseCsc):
                     )
 
                     # TODO: Use the ErrorCode.CCW_FOLLOWING_ERROR instead in
-                    # ts_xml v23.0.0
+                    # ts_xml v23.0.0 (DM-48161)
                     await self.evt_errorCode.set_write(
                         errorCode=6,
                         errorReport="Camera cable wrap not following closely enough",
@@ -642,7 +642,7 @@ class RotatorCsc(hexrotcomm.BaseCsc):
 
             if no_new_track_command:
                 # TODO: Use the ErrorCode.NO_NEW_TRACK_COMMAND instead in
-                # ts_xml v23.0.0
+                # ts_xml v23.0.0 (DM-48161)
                 await self.evt_errorCode.set_write(
                     errorCode=7,
                     errorReport="No new track command in timeout",

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -354,6 +354,10 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             self.enable_mock_ccw_telemetry = False
             await asyncio.wait_for(self.mock_ccw_task, timeout=STD_TIMEOUT)
             await self.assert_next_summary_state(salobj.State.FAULT)
+
+            # TODO: At ts_xml v23.0.0, use ErrorCode.NO_NEW_CCW_TELEMETRY
+            # instead.
+            await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=4)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode, errorCode=ErrorCode.CONTROLLER_FAULT
             )
@@ -388,6 +392,10 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             self.ccw_following_error = self.csc.config.max_ccw_following_error + 0.1
             await self.assert_next_ccw_following_error()
             await self.assert_next_summary_state(salobj.State.FAULT)
+
+            # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
+            # instead.
+            await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode, errorCode=ErrorCode.CONTROLLER_FAULT
             )
@@ -412,6 +420,10 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             self.ccw_following_error = -(self.csc.config.max_ccw_following_error + 0.1)
             await self.assert_next_ccw_following_error()
             await self.assert_next_summary_state(salobj.State.FAULT)
+
+            # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
+            # instead.
+            await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode,
                 errorCode=ErrorCode.CONTROLLER_FAULT,
@@ -444,6 +456,10 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.assert_next_summary_state(
                 salobj.State.FAULT, flush=False, timeout=STD_TIMEOUT
             )
+
+            # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
+            # instead.
+            await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode,
                 errorCode=ErrorCode.CONTROLLER_FAULT,
@@ -989,6 +1005,9 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
                 flush=False, timeout=STD_TIMEOUT
             )
             self.assertFalse(data.inPosition)
+
+            self.remote.evt_errorCode.flush()
+
             await self.remote.cmd_trackStart.start(timeout=STD_TIMEOUT)
 
             # Immediately send a track commands (not giving the CSC time to see
@@ -1022,6 +1041,10 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.assert_next_sample(
                 topic=self.remote.evt_tracking, tracking=False, noNewCommand=True
             )
+
+            # TODO: At ts_xml v23.0.0, use ErrorCode.NO_NEW_TRACK_COMMAND
+            # instead.
+            await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=7)
 
     async def assert_next_ccw_following_error(
         self,

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -356,7 +356,7 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.assert_next_summary_state(salobj.State.FAULT)
 
             # TODO: At ts_xml v23.0.0, use ErrorCode.NO_NEW_CCW_TELEMETRY
-            # instead.
+            # instead. (DM-48161)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=4)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode, errorCode=ErrorCode.CONTROLLER_FAULT
@@ -394,7 +394,7 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.assert_next_summary_state(salobj.State.FAULT)
 
             # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
-            # instead.
+            # instead. (DM-48161)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode, errorCode=ErrorCode.CONTROLLER_FAULT
@@ -422,7 +422,7 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             await self.assert_next_summary_state(salobj.State.FAULT)
 
             # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
-            # instead.
+            # instead. (DM-48161)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode,
@@ -458,7 +458,7 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             )
 
             # TODO: At ts_xml v23.0.0, use ErrorCode.CCW_FOLLOWING_ERROR
-            # instead.
+            # instead. (DM-48161)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=6)
             await self.assert_next_sample(
                 topic=self.remote.evt_errorCode,
@@ -1043,7 +1043,7 @@ class TestRotatorCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
             )
 
             # TODO: At ts_xml v23.0.0, use ErrorCode.NO_NEW_TRACK_COMMAND
-            # instead.
+            # instead. (DM-48161)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=7)
 
     async def assert_next_ccw_following_error(


### PR DESCRIPTION
* Increase the delay time from 0.1 sec to 0.2 sec in ``RotatorCsc.do_move()``.
* Publish the error code events.